### PR TITLE
remove InitialBinding from GetMaterialApp

### DIFF
--- a/exemples/getx_pattern_example/lib/app/routes/app_pages.dart
+++ b/exemples/getx_pattern_example/lib/app/routes/app_pages.dart
@@ -1,14 +1,17 @@
-
 import 'package:get/get.dart';
 import 'package:getx_pattern/app/bindings/details_binding.dart';
+import 'package:getx_pattern/app/bindings/home_binding.dart';
 import 'package:getx_pattern/app/ui/android/details/details_page.dart';
 import 'package:getx_pattern/app/ui/android/home/home_page.dart';
 part './app_routes.dart';
 
-
 class AppPages {
   static final pages = [
-    GetPage(name: Routes.INITIAL, page:()=> HomePage(),),
-    GetPage(name: Routes.DETAILS, page:()=> DetailsPage(), binding: DetailsBinding()),
+    GetPage(
+        name: Routes.INITIAL, page: () => HomePage(), binding: HomeBinding()),
+    GetPage(
+        name: Routes.DETAILS,
+        page: () => DetailsPage(),
+        binding: DetailsBinding()),
   ];
 }

--- a/exemples/getx_pattern_example/lib/main.dart
+++ b/exemples/getx_pattern_example/lib/main.dart
@@ -10,7 +10,6 @@ import 'app/ui/theme/app_theme.dart';
 void main() {
   runApp(GetMaterialApp(
     debugShowCheckedModeBanner: false,
-    initialBinding: HomeBinding(),
     initialRoute: Routes.INITIAL,
     theme: appThemeData,
     defaultTransition: Transition.fade,


### PR DESCRIPTION
No need to pass HomeBinding to initialBinding property in the GetMaterialApp When it can be pass to GetPage via its binding property.